### PR TITLE
Don't ignore self-pulbished info.

### DIFF
--- a/release/handlers.js
+++ b/release/handlers.js
@@ -144,17 +144,15 @@ class Handlers {
       const INDEX = event.currentIndex;
       const SESSION = event.subscription.sessions[INDEX];
       if (SESSION && INDEX < event.length) {
-        if (SESSION.getID() !== event.session.getID()) {
-          DEBUG('notifying sessionID: %s', SESSION.getID());
-          SESSION.send([
-            protocols_1.outgoingChannel.EVENT,
-            SESSION.getSubscriptionID(event.topic),
-            event.subscription.subscriptionID,
-            event.message.incoming[3],
-            event.message.incoming[4],
-            event.message.incoming[5],
-          ]);
-        }
+        DEBUG('notifying sessionID: %s', SESSION.getID());
+        SESSION.send([
+          protocols_1.outgoingChannel.EVENT,
+          SESSION.getSubscriptionID(event.topic),
+          event.subscription.subscriptionID,
+          event.message.incoming[3],
+          event.message.incoming[4],
+          event.message.incoming[5],
+        ]);
         event.currentIndex++;
         setImmediate(Handlers.notify, event);
       } else {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -168,17 +168,15 @@ class Handlers {
     const INDEX: number = event.currentIndex;
     const SESSION: SessionInterface = event.subscription.sessions[INDEX];
     if (SESSION && INDEX < event.length) {
-      if (SESSION.getID() !== event.session.getID()) {
-        DEBUG('notifying sessionID: %s', SESSION.getID());
-        SESSION.send([
-          outgoingChannel.EVENT,
-          SESSION.getSubscriptionID(event.topic),
-          event.subscription.subscriptionID,
-          event.message.incoming[3],
-          event.message.incoming[4],
-          event.message.incoming[5],
-        ]);
-      }
+      DEBUG('notifying sessionID: %s', SESSION.getID());
+      SESSION.send([
+        outgoingChannel.EVENT,
+        SESSION.getSubscriptionID(event.topic),
+        event.subscription.subscriptionID,
+        event.message.incoming[3],
+        event.message.incoming[4],
+        event.message.incoming[5],
+      ]);
       event.currentIndex++;
       setImmediate(Handlers.notify, event);
     } else {


### PR DESCRIPTION
The spec says 
> If the Broker is able to fulfill and allowing the publication, the
> Broker will send the event to all current Subscribers of the topic of
> the published event. "

So we shouldn't ignore the self-published info.  Otherwise, the default test code from autobahn-js won't work. (That's why I found this issue)